### PR TITLE
fix attention code to produce cell wise attention weights

### DIFF
--- a/model_components.py
+++ b/model_components.py
@@ -82,10 +82,8 @@ def task_specific_attention(inputs, output_size,
                                                   activation_fn=activation_fn,
                                                   scope=scope)
 
-        vector_attn = tf.reduce_sum(tf.multiply(input_projection, attention_context_vector), axis=2)
-        attention_weights_softmax = tf.nn.softmax(vector_attn, dim=1)
-        attention_weights = tf.expand_dims(attention_weights_softmax, axis=-1)
-
+        vector_attn = tf.reduce_sum(tf.multiply(input_projection, attention_context_vector), axis=2, keep_dims=True)
+        attention_weights = tf.nn.softmax(vector_attn, dim=-1)
         weighted_projection = tf.multiply(input_projection, attention_weights)
 
         outputs = tf.reduce_sum(weighted_projection, axis=1)

--- a/model_components.py
+++ b/model_components.py
@@ -83,7 +83,7 @@ def task_specific_attention(inputs, output_size,
                                                   scope=scope)
 
         vector_attn = tf.reduce_sum(tf.multiply(input_projection, attention_context_vector), axis=2, keep_dims=True)
-        attention_weights = tf.nn.softmax(vector_attn, dim=-1)
+        attention_weights = tf.nn.softmax(vector_attn, dim=1)
         weighted_projection = tf.multiply(input_projection, attention_weights)
 
         outputs = tf.reduce_sum(weighted_projection, axis=1)

--- a/model_components.py
+++ b/model_components.py
@@ -81,9 +81,10 @@ def task_specific_attention(inputs, output_size,
         input_projection = layers.fully_connected(inputs, output_size,
                                                   activation_fn=activation_fn,
                                                   scope=scope)
-        attention_weights = tf.nn.softmax(
-            tf.multiply(input_projection, attention_context_vector)
-        )
+
+        vector_attn = tf.reduce_sum(tf.multiply(input_projection, attention_context_vector), axis=2)
+        attention_weights_softmax = tf.nn.softmax(vector_attn, dim=1)
+        attention_weights = tf.expand_dims(attention_weights_softmax, axis=-1)
 
         weighted_projection = tf.multiply(input_projection, attention_weights)
 


### PR DESCRIPTION
tensorflow multiply is a element-wise multiply and does not sum up the values along the cell wise ```attention_context_vector``` so added reduce_sum for the same and expand_dims to match shape for ```weighted_projection``` computation